### PR TITLE
Call out that supernode 2 was removed

### DIFF
--- a/content/nodes/supernode2.md
+++ b/content/nodes/supernode2.md
@@ -3,7 +3,11 @@ title: "Supernode 2"
 aliases: [/networking/supernode1/]
 ---
 
-Supernode 2 (node 570) is located at 1196 Metropolitan Avenue in Brooklyn New York. The installation provides mesh and internet connectivity for building residents as well as some areas of the East Williamsburg and Bushwick neighborhoods.
+⚠️  **Supernode 2 has been removed** ⚠️
+
+Supernode 2 (node 570) was located at 1196 Metropolitan Avenue in Brooklyn New York. On October 7th, 2018 it was taken down due to a landlord dispute.
+
+The information below is a point of reference for how supernode 2 was configured.
 
 ![Supernode 2 radios](/img/nycmesh-570-radios.png)
 


### PR DESCRIPTION
This pull request updates the [Supernode 2](https://docs.nycmesh.net/nodes/supernode2/) documentation to call out that it is no longer around. This will hopefully reduce any confusion for prior and future members.