### PR TITLE
Remove CSS class that uppercases "NYC Mesh"

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -2,7 +2,7 @@
 <div class="relative w-30-ns ph4-l ph3 flex justify-end-ns br bg-near-white b--light-gray">
 	<div class="mw5 w-100 overflow-y-hidden flex flex-column">
 		<div class="nowrap flex items-center justify-start h3">
-			<a href="/" title="Home" class="f3-ns f4 ttu fw7 black nowrap flex items-center">
+			<a href="/" title="Home" class="f3-ns f4 fw7 black nowrap flex items-center">
 				<img src="/img/logo.svg" class="h2 mr2" /> 
 		        <span class="f4">NYC Mesh
 	            <span class="ml1 blue f5">Docs</span></span>


### PR DESCRIPTION
Fixes nycmeshnet/docs#35