### PR TITLE
Avoid smart fraction parsing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,3 +3,7 @@ relativeurls = true
 languageCode = "en-us"
 title = "NYC Mesh Docs"
 pluralizeListTitles = false
+
+# Markdown config
+[blackfriday]
+fractions = false


### PR DESCRIPTION
This fixes IP addresses like 192.168.88.1/24 rendering with 1/24 as a fraction.
Example at https://docs.nycmesh.net/hardware/config/