### PR TITLE
Jade/proofread

### DIFF
--- a/content/hardware/litebeamac.md
+++ b/content/hardware/litebeamac.md
@@ -3,7 +3,7 @@ title: "Ubiquiti LiteBeam AC"
 ---
 The LiteBeamAC is a very good, cheap directional router. We use it for most rooftop installs. As with all Ubiquiti gear you need to flash it with the latest firmware first. Often they ship with old beta firmware, and the latest firmware usually gets you faster speeds.
 
-The AC in the name is not 802.11ac, it is Ubiquiti's own protocol. These devices can only connect to other Ubiquiti "AC" devices.
+The AC in the name is not [802.11ac] (https://en.wikipedia.org/wiki/IEEE_802.11), it is Ubiquiti's own protocol. These devices can only connect to other Ubiquiti "AC" devices.
 
 ![Ubiquity LiteBeam 5AC Gen2](/img/hardware/ubiquity_litebeam5acgen2.png)
 
@@ -15,7 +15,10 @@ Gen2 comes with a more sturdy mount (though less range) and also a management 2.
 
 LiteBeams are very directional so use the built-in alignment tool to get the strongest signal. We like to get better than -65db. Very close to the supernodes you can get -45db.
 
-The default IP is https://192.168.1.20/ with name:ubnt pwd:ubnt
+The default IP is https://192.168.1.20/ with:
+
+* name:ubnt
+* pwd:ubnt
 
 For Supernode1 we assign IP addresses in the 192.168.42.xxx range
 

--- a/content/hardware/tplink.md
+++ b/content/hardware/tplink.md
@@ -12,41 +12,44 @@ An indoor router, connected by ethernet cable to the outdoor router, is required
 
 
 ### Pre-Configuration Best Practices
-**for volunteer installers**
+**For volunteer installers**
 
 Before configuring, ask the user member to tell you:
+
 * Whether they would like to use the TP-Link router we supply or their own router
 * A username and password for the router
 * An SSID and password for the home wireless network
 
 ### TP-Link TL-WR841N Router Configuration Instructions
-**for volunteer installers and DIY installers**
-
-1.  Plug the ethernet cable from the outdoor antenna/router into the TP-Link’s blue WAN port.
-1.  Plug the power adapter into the wall and the cable into the power socket of the router. The router will turn on automatically.
-1.  Connect the installation laptop to the router by plugging an  Ethernet patch cable into the yellow LAN port or via Wifi (see the underside of the router for SSID and pwd). 
+**For volunteer installers and DIY installers**
 
 ![alt text](https://i.imgur.com/5BVxd9h.jpg "TP-Link Router")
 
-1.  Navigate to the router dashboard in an Internet browser. The Default IP address is **192.168.0.1** 
+1.  Plug the ethernet cable from the outdoor antenna/router into the TP-Link’s blue WAN port.
+1.  Plug the power adapter into the wall and the cable into the power socket of the router. The router will turn on automatically.
+1.  Connect the installation laptop to the router by plugging an Ethernet patch cable into the yellow LAN port or via Wifi (see the underside of the router for SSID and pwd)
+
+1.  Navigate to the router dashboard in an Internet browser. The Default IP address is **192.168.0.1**
     *  Username: **admin**
-    *  Password: **admin** 
-    
-1.  Set up the guest WiFi to “**-NYC Mesh Community WiFi-**” (including the dashes). 
-Navigate to “Guest Network” and set as follows:
+    *  Password: **admin**
 
-![alt text](https://i.imgur.com/BXzdita.jpg "Guest Network Configuration Settings")
-[Obligations](https://www.nycmesh.net/faq#obligations)
+1.  Set up the guest WiFi to “**-NYC Mesh Community WiFi-**” (including the dashes).
+Navigate to “Guest Network” and set as follows: ![alt text](https://i.imgur.com/BXzdita.jpg "Guest Network Configuration Settings")
 
-1.  Set up the home WiFi. 
+1.  Set up the home WiFi.
 Navigate to Wireless > Basic Settings
-to set the home WiFi network SSID you wish to use and  navigate to Wireless > Wireless Security to set the password. 
+to set the home WiFi network SSID you wish to use and  navigate to Wireless > Wireless Security to set the password.
 
 1.  Replace the router’s admin/admin login with a more secure username and password.
-Navigate to System Tools > Password and input a new username and password. 
+Navigate to System Tools > Password and input a new username and password.
+
+1. Please read [Obligations](https://www.nycmesh.net/faq#obligations)
+
+
+
 
 ### Optional TP-Link TL-WR841N Firmware Upgrade
-**for volunteer installers**
+**For volunteer installers**
 
 If you have time you should pre-configure the router as much as possible, including upgrading the firmware to the latest version. To do that the router does not need to be connected to a network. It can be pre-configured following the above steps excluding point 1.
 
@@ -54,11 +57,10 @@ If you have time you should pre-configure the router as much as possible, includ
 1.  Connect to **192.168.0.1** and log in with the username and password you set for the router.
 1.  Go to System Tools > Firmware Upgrade.
 1.  Click Choose File to locate the downloaded firmware file, and click Upgrade.
-1.  Setting the time is not a necessity but nice to do. Go to System Tools > Time Settings. You can use [apple NTP](time.apple.com), [pool.org](pool.ntp.org) and/or [Google](time1.google.com).
+1.  Setting the time is not a necessity but nice to do. Go to System Tools > Time Settings. You can use [apple NTP](http://time.apple.com), [pool.org](http://pool.ntp.org) and/or [Google](http://time1.google.com).
 
 
 ### Support
-**for volunteer installers and DIY installers**
+**For volunteer installers and DIY installers**
 
 A Quick Installation Guide and User Guide for the TP-Link TL-WR841N router can be downloaded [here](https://www.tp-link.com/us/download/TL-WR841N.html).
-

--- a/content/intro/typical Installs.md
+++ b/content/intro/typical Installs.md
@@ -59,7 +59,7 @@ Other rooftops can connect to the OmniTik by using another Omnitik if they are c
 
 **3.- A good rooftop can be "beefed up" to allow for more connectivity.**
 
-If the rooftop is interesting (at a good location, it's high enough, etc) we may install "sectors" or other type of equipement. Sectors are antennas that communicate via Ubiquiti's AirMax protocol and have a longer range than an OmniTik. Additionally, we may connect to two hubs, etc....
+If the rooftop is interesting (at a good location, it's high enough, etc) we may install "[sectors] (/hardware/liteap/)" or other type of equipement. Sectors are antennas that communicate via Ubiquiti's AirMax protocol and have a longer range than an OmniTik. Additionally, we may connect to two hubs, etc....
 
 Here four examples.
 
@@ -70,7 +70,7 @@ Here four examples.
 
 <br><hr><br>
 
-**4.- A building can connect to an other building with an OmniTik using a different antenna**
+**4.- A building can connect to another building with an OmniTik using a different antenna**
 
 A building can connect to another building with an OmniTik using a [SXT] ( /hardware/sxtsqg5acd/ ) antenna. It can then serve one or several apartments.
 


### PR DESCRIPTION
Fixed some links, typos, and formatting while I read the docs. 

Affects only 3 pages:

- `/intro-typical-installs`
- `/hardware/litebeammac`
- `/hardware/tplink`

Was tested visually with local hugo server