### PR TITLE
link to the correct repository instead of the archived one

### DIFF
--- a/content/software/_index.md
+++ b/content/software/_index.md
@@ -15,5 +15,5 @@ We are working to improve our router firmware, which is a fork of LibreMesh with
 
 #### Website
 
-*   [nycmeshnet.github.io](https://github.com/nycmeshnet/nycmeshnet.github.io) - Our public website is hosted by Github and its full source is available here.
+*   [nycmesh.net](https://github.com/nycmeshnet/nycmesh.net) - Our public website is hosted by Github and its full source is available here.
 *   [map-nodes](https://github.com/nycmeshnet/map-nodes) - This script pulls from our node spreadsheet and renders the data which powers the node map on our website.


### PR DESCRIPTION
the docs still link to the old repository for the website, which is now archived. This should be replaced with a link to the new repository.

