### PR TITLE
Make the timestamp author fallback to "unknown" if it can't be found.

### DIFF
--- a/layouts/partials/timestamp.html
+++ b/layouts/partials/timestamp.html
@@ -2,7 +2,7 @@
   <p>
     Last updated
     {{/* Go-specific layout string that looks like a time, don't change. */}}
-    {{- .Lastmod.Format "January 2, 2006" }} by {{ .GitInfo.AuthorName -}}
+    {{- .Lastmod.Format "January 2, 2006" }} by {{ if .GitInfo }}{{ .GitInfo.AuthorName -}}{{else}} unknown {{end}}
   </p>
 </div>
 


### PR DESCRIPTION
Right now, if there is no git info for a specific page, you will get an error whenever you try to serve the site via `hugo server`. It looks something like this:
```
Error: Error building site: failed to render pages: render of "page" failed: execute of template failed: template: _default/single.html:7:8: executing "main" at <partial "timestamp" .>: error calling partial: "/Users/bh/Documents/code/docs/layouts/partials/timestamp.html:5:59": execute of template failed: template: partials/timestamp.html:5:59: executing "partials/timestamp.html" at <.GitInfo.AuthorName>: nil pointer evaluating *gitmap.GitInfo.AuthorName
```

With these changes the site will build & get served correctly. Instead of getting that error the page in question will show up with "unknown" as the author like so:
![image](https://user-images.githubusercontent.com/1084688/103546493-12495980-4e71-11eb-9d42-71d6949bdb21.png)

