### PR TITLE
Add EP-R6 to Omni Tutorial

### DIFF
--- a/content/hardware/epr6.md
+++ b/content/hardware/epr6.md
@@ -62,9 +62,57 @@ coming
 
 
 ## Switched Mode ##
-To convert the EP-R6 to switched mode, there's now a simple wizard to in the gui to help.  
-[Here's Ubiquiti's guide](https://help.ui.com/hc/en-us/articles/217990978-EdgeRouter-Configure-an-EdgeRouter-as-a-Layer-2-Switch)
- 
+To convert the EP-R6 to switched mode, there's now a [simple wizard](https://help.ui.com/hc/en-us/articles/217990978-EdgeRouter-Configure-an-EdgeRouter-as-a-Layer-2-Switch#1) in the GUI to help.
+
+### Extend an OmniTik ###
+A common use case for the EP-R6 as a switch is to add more PoE-capable ports to an OmniTik router on the roof. In order to preserve isolation between these ports and on the OmniTik, we need to make the switch __VLAN-Aware__. The following instructions assume the OmniTik has been configured with the [standard configuration](https://configgen.nycmesh.net/?device=Omnitik5AC&template=rooftop-ospf.rsc.tmpl) and IP allocations.
+
+**1. Start the Wizard**
+
+In the web interface, navigate to the "Wizards" tab on the top right of the screen. On the left sidebar, click "Switch".
+Choose Static IP. You are probably connected directly to the switch right now, so you don't want to lose access to it while there's no DHCP server!
+
+Log into the OmniTik you are planning on connecting the switch to; we are going to find an unused IP in its /26 subnet. On the left sidebar under IP->DHCP Server, click the "Leases" tab, and hit "Add New". Type in the address you are allocating, __uncheck__ "Enabled", and type `nycmesh-xxxx-epr6` in the "Comment" (where `xxxx` is the network number to which this will be attached).
+
+Type this address into the switch with a /26 subnet with the OmniTik's /26 IP Address as the gateway. Use `10.10.10.10` as the DNS server.
+
+**2. Set the VLANs on the EP-R6**
+
+Under "VLAN Aware", check "Enabled". Depending on which port will be connected to the OmniTik (the "trunk" port), you will set the VLANs using a combination of the OmniTik's and the EP-R6's port numbers.
+
+_Example:_ EP-R6 is plugged into Port 3 on the OmniTik, and we want to isolate Ports 1-5 on the EP-R6.
+
+```
+eth0: vid 301,302,303,304,305
+eth1: pvid 301
+eth2: pvid 303
+eth3: pvid 303
+eth4: pvid 304
+eth5: pvid 305
+```
+
+In layman's terms, The PVID tags the port and VID tells where to send the tagged traffic out. The first digit will be the port number of the OmniTik, and the last digit will be the port number of the EP-R6. After setting up your credentials you can hit apply and reboot the router.
+
+**3. Add the VLANs to the OmniTik**
+
+Because eth0 did not have a PVID set, you should be able to access the switch using its new IP address without additional hardware. However, we need to configure the OmniTik to _receive_ the tagged traffic and add them to the mesh bridge.
+
+On the OmniTik, navigate to Interfaces on the left sidebar. Click Add New->VLAN for each port on the EP-R6 we are configuring. Let's use the EP-R6 `eth1` from above as our example:
+
+```
+Name: ether1.301
+VLAN ID: 301
+Interface: ether3
+```
+
+Hit OK to save. Once you do this for each port on the EP-R6, you can navigate to the left sidebar and go to Bridge. Under the "Ports" tab, click "Add New" for each VLAN you are configuring. Select the Interface you just created (`ether1.301`) and the Bridge `mesh`. Hit OK, and do this for each VLAN interface.
+
+__4. Test it!__
+
+The easiest way to test your configuration is by connecting a DHCP client (like a router) to the port and testing traffic flow. Plug it into any of the configured ports of the EP-R6, where you will see the port turn purple, orange, or green on the top of the EP-R6's GUI (purple:10Mbps, orange:100Mbps, green:1G).
+
+In the left sidebar of the OmniTik, under IP->DHCP Server, click on the "Leases" tab and check that it got an IP. Lastly, under Interfaces, check if traffic is visible on that particular VLAN. If you can see activity on that interface, you did it! 🎉
+
 ## Routed Mode ( NYCMesh Hub Node - BGP ) ##
 You will need to know the following to be able to continue:
 BGP ASN - Autonomous System Number within the network


### PR DESCRIPTION
Using Ubiquiti's new wizard guide, added guide to configuring a EP-R6 switch with isolated VLANs to an OmniTik router.