### PR TITLE
Update wireguard vpn relative link

### DIFF
--- a/content/networking/vpnwireguardospf.md
+++ b/content/networking/vpnwireguardospf.md
@@ -2,7 +2,7 @@
 title: "VPN - WireGuard + OSPF"
 ---
 
-[WireGuard](https://wireguard.com/) is generally described on another page, here: [VPN - Wireguard]({{ relref "vpnwireguard.md"}}). This page is about what is needed to configure WireGuard for routing over the VPN; especially with a focus on OSPF.
+[WireGuard](https://wireguard.com/) is generally described on another page, here: [VPN - Wireguard]({{< relref "vpnwireguard.md" >}}). This page is about what is needed to configure WireGuard for routing over the VPN; especially with a focus on OSPF.
 
 ## A Note on Cryptokey Routing
 It's worth a section to touch on the cryptokey routing feature of WireGuard and how it works with the mesh.  


### PR DESCRIPTION
I just clicked this link, noticed it broke.

Should be similar to this line: https://github.com/nycmeshnet/docs/blob/0d12c87553214eedcb0a874a38d3cc40f710a351/content/networking/vpn.md?plain=1#L43

Update: [Netlify deploy seems to work :)](https://deploy-preview-190--quirky-edison-0960a5.netlify.app/networking/vpnwireguardospf/)