### PR TITLE
Change redirect links to point to MeshDB Pages To 

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -236,13 +236,13 @@ force = true
 
 [[redirects]]
 from = "/installs/nn/"
-to = "https://nycmesh.net/nn"
+to = "https://forms.nycmesh.net/nn-assign" #update to point to MeshDB page
 status = 302
 force = true
 
 [[redirects]]
 from = "/nn"
-to = "https://nycmesh.net/nn"
+to = "https://forms.nycmesh.net/nn-assign" #update to point to MeshDB page
 status = 302
 force = true
 
@@ -254,7 +254,7 @@ force = true
 
 [[redirects]]
 from = "/installs/query/"
-to = "https://nycmesh.net/query"
+to = "https://forms.nycmesh.net/query" #update to point to MeshDB page
 status = 302
 force = true
 
@@ -315,7 +315,7 @@ force = true
 
 [[redirects]]
 from = "/networking/nn/"
-to = "https://nycmesh.net/nn"
+to = "https://forms.nycmesh.net/nn-assign" #updated to point to MeshDB page
 status = 302
 force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -241,7 +241,7 @@ status = 302
 force = true
 
 [[redirects]]
-from = "/nn/"
+from = "/nn"
 to = "https://nycmesh.net/nn"
 status = 302
 force = true


### PR DESCRIPTION
Please approve but wait until MeshDB cutover to merge.

Updates nycmesh.net/docs redirects for NN Tool and Query Tool pages to point to the MeshDB version of those pages.